### PR TITLE
#247イベント発生時にUIの非表示、終了時にUIの再表示の命令追加

### DIFF
--- a/PicGather/Assets/Event/EventBase.cs
+++ b/PicGather/Assets/Event/EventBase.cs
@@ -25,5 +25,6 @@ public class EventBase : MonoBehaviour {
     protected virtual void Finish()
     {
         UIEnabled.Enabled();
+        Destroy(this.gameObject);
     }
 }

--- a/PicGather/Assets/Event/EventBase.cs
+++ b/PicGather/Assets/Event/EventBase.cs
@@ -24,5 +24,6 @@ public class EventBase : MonoBehaviour {
     /// </summary>
     protected virtual void Finish()
     {
+        UIEnabled.Enabled();
     }
 }

--- a/PicGather/Assets/Event/EventManager.cs
+++ b/PicGather/Assets/Event/EventManager.cs
@@ -28,22 +28,24 @@ public class EventManager : MonoBehaviour {
     /// <summary>
     /// イベントの情報を統括するメンバ変数
     /// </summary>
-    public EventInfo EventInfomation = new EventInfo();
+    public EventInfo EventInformation = new EventInfo();
 
     void Start()
     {
-        EventInfomation.BeginEvent = false;
-        EventInfomation.NowPlayingEvent = false;
+        EventInformation.BeginEvent = false;
+        EventInformation.NowPlayingEvent = false;
     }
 
 	// Update is called once per frame
 	void Update () {
-        if(EventInfomation.BeginEvent)
+        if(EventInformation.BeginEvent)
         {
-            Instantiate(EventInfomation.PlayingEvent);
-            EventInfomation.NowPlayingEvent = true;
+            Instantiate(EventInformation.PlayingEvent);
+            EventInformation.NowPlayingEvent = true;
 
-            EventInfomation.BeginEvent = false;
+            EventInformation.BeginEvent = false;
+
+            UIEnabled.Unavailable();
         }
 	}
 
@@ -54,10 +56,10 @@ public class EventManager : MonoBehaviour {
     public void BeginEvent(GameObject eventPrefab)
     {
         /// イベント中なら発生させない
-        if (EventInfomation.PlayingEvent) return;
+        if (EventInformation.PlayingEvent) return;
 
-        EventInfomation.PlayingEvent = eventPrefab;
-        EventInfomation.BeginEvent = true;
+        EventInformation.PlayingEvent = eventPrefab;
+        EventInformation.BeginEvent = true;
     }
 
 }


### PR DESCRIPTION
# イベント発生時、終了時のUIの表示非表示の切り替えをする命令を追加しました。

* EventManager.cs内、イベントのプレハブをinstantiateする部分でUIを非表示にする命令を呼ぶようにしました。

* Eventbase.cs内、イベント終了時に呼び出されるFinish関数に追記しました。
 * UIを再度表示する命令を追加。
 * 自身をDestroyする命令を追加。
* 誤字修正しました。
  * public EventInfo EventInfomation = new EventInfo();<br>
    ↓<br>
    public EventInfo EventInformation = new EventInfo();

